### PR TITLE
Renaming distribution name from idb to interbase

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -43,7 +43,8 @@ jobs:
       name: pypi
       url: https://test.pypi.org/p/interbasepython
     permissions:
-      id-token: write 
+      id-token: write
+    if: github.ref == 'refs/heads/main'
     steps:                       
       - uses: actions/download-artifact@v2
         with:
@@ -64,7 +65,7 @@ jobs:
       url: https://pypi.org/p/interbasepython
     permissions:
       id-token: write
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' && startsWith(github.ref, 'refs/tags/v')
     steps:                       
       - uses: actions/download-artifact@v2
         with:

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,5 +1,5 @@
 Metadata-Version: 1.1
-Name: idb
+Name: interbase
 Version: 1.5.0
 Summary: InterBase RDBMS bindings for Python.
 Home-page: https://github.com/Embarcadero/InterBasePython

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ all-files = True
 
 
 [metadata]
-name = idb
+name = interbase
 version = 1.5.0
 description = InterBase RDBMS bindings for Python.
 long_description = file: README.md


### PR DESCRIPTION
Following #1, the distribution name has been changed from idb to interbase. This change only affects the distribution installation process, importing package must work out as before.